### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/apps/api/api-auth/src/routes/auth.routes.ts
+++ b/apps/api/api-auth/src/routes/auth.routes.ts
@@ -1,12 +1,20 @@
+import rateLimit from 'express-rate-limit';
 import express from 'express';
 import { validateData } from '../middleware/validationMiddleware';
 import { register, login, verifyToken, protectedRoute } from '../controllers/AuthController';
 import { UserRegistrationSchema, UserLoginSchema } from '@shared-types';
 
+// Rate limiter for protected routes
+const protectedRouteLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: 'Too many requests from this IP, please try again later.'
+});
+
 const router = express.Router();
 
 router.post('/register', validateData(UserRegistrationSchema), register);
 router.post('/login', validateData(UserLoginSchema), login);
-router.get('/protected', verifyToken, protectedRoute);
+router.get('/protected', protectedRouteLimiter, verifyToken, protectedRoute);
 
 export default router;

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react-dom": "19.0.0",
     "react-router-dom": "6.29.0",
     "uuid": "^11.1.0",
-    "zod": "^4.0.17"
+    "zod": "^4.0.17",
+    "express-rate-limit": "^8.0.1"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/balajidharma/node-express-hub/security/code-scanning/1](https://github.com/balajidharma/node-express-hub/security/code-scanning/1)

To fix the missing rate limiting, we should add a rate-limiting middleware to the `/protected` route. The best way to do this is to use a well-known package such as `express-rate-limit`. We will import `express-rate-limit`, define a rate limiter (e.g., allowing 100 requests per 15 minutes per IP), and apply it specifically to the `/protected` route. This approach avoids changing the behavior of other routes and does not interfere with existing functionality.

**Steps:**
- Import `express-rate-limit` at the top of the file.
- Define a rate limiter instance with reasonable defaults.
- Add the rate limiter as middleware to the `/protected` route (before `verifyToken`).
- No changes to other routes or logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
